### PR TITLE
Fix error when dumping from an image that has a space in its path.

### DIFF
--- a/main.xm
+++ b/main.xm
@@ -31,6 +31,12 @@ static BOOL shouldDLopen32BitExecutables=NO;
 #include "ParsingFunctions.m"
 
 
+static NSString *bash_escape(NSString *rawCommand){
+	NSString *escapedString = [rawCommand stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
+	escapedString = [escapedString stringByReplacingOccurrencesOfString:@" " withString:@"\\ "];
+	return escapedString;
+}
+
 /****** Recursive file search ******/
 
 static void list_dir(const char *dir_name,BOOL writeToDisk,NSString *outputDir,BOOL getSymbols,BOOL recursive,BOOL simpleHeader,BOOL skipAlreadyFound,BOOL skipApplications){
@@ -270,12 +276,13 @@ extern "C" int parseImage(char *image,BOOL writeToDisk,NSString *outputDir,BOOL 
 				system([exec UTF8String]);
 			}*/
 
+			NSString *escapedImage = bash_escape([NSString stringWithUTF8String:image]);
+
 			#if defined (__x86_64__) || defined (__i386__)
-				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/local/lib/libclassdumpdyld.dylib %s",image];
+				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/local/lib/libclassdumpdyld.dylib %s",[escapedImage UTF8String]];
 			#else
-				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/lib/libclassdumpdyld.dylib %s",image];
+				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/lib/libclassdumpdyld.dylib %s",[escapedImage UTF8String]];
 			#endif			
-			
 
 			if (writeToDisk){
 				tryWithLib=[tryWithLib stringByAppendingString:[NSString stringWithFormat:@" -o %@",outputDir]];

--- a/main.xm
+++ b/main.xm
@@ -279,9 +279,9 @@ extern "C" int parseImage(char *image,BOOL writeToDisk,NSString *outputDir,BOOL 
 			NSString *escapedImage = bash_escape([NSString stringWithUTF8String:image]);
 
 			#if defined (__x86_64__) || defined (__i386__)
-				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/local/lib/libclassdumpdyld.dylib %s",[escapedImage UTF8String]];
+				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/local/lib/libclassdumpdyld.dylib %@",escapedImage];
 			#else
-				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/lib/libclassdumpdyld.dylib %s",[escapedImage UTF8String]];
+				NSString *tryWithLib=[NSString stringWithFormat:@"DYLD_INSERT_LIBRARIES=/usr/lib/libclassdumpdyld.dylib %@",escapedImage];
 			#endif			
 
 			if (writeToDisk){


### PR DESCRIPTION
Escape the image path before shelling out using bash. Eventually we'll want to drop the usage of system() but for now this solution works. With these patches I successfully dumped headers from "Working Copy" which has 2 spaces in its path.