### PR TITLE
fixes a crash on tvOS 10 Foundation framework dump at NSLeafProxy

### DIFF
--- a/ParsingFunctions.m
+++ b/ParsingFunctions.m
@@ -1326,7 +1326,12 @@ NSString * generateMethodLines(Class someclass,BOOL isInstanceMethod,NSMutableAr
 					returnString=[[[returnString autorelease] stringByAppendingString:[NSString stringWithFormat:@"%@:(%@)arg%d ",[selValuesArray objectAtIndex:i-2],methodTypeSameAsProperty,i-1]] retain];
 				}
 				else{
-					returnString=[[[returnString autorelease] stringByAppendingString:[NSString stringWithFormat:@"%@:(%@)arg%d ",[selValuesArray objectAtIndex:i-2],commonTypes([NSString stringWithCString:methodType encoding:NSUTF8StringEncoding],nil,NO),i-1]] retain];
+                    //fixes a crash, probably needs a more proper solution
+                    if (selValuesArray.count > 1)
+                    {
+                        
+                        returnString=[[[returnString autorelease] stringByAppendingString:[NSString stringWithFormat:@"%@:(%@)arg%d ",[selValuesArray objectAtIndex:i-2],commonTypes([NSString stringWithCString:methodType encoding:NSUTF8StringEncoding],nil,NO),i-1]] retain];
+                    }
 				}
 				[methodTypeSameAsProperty release];
 				free(methodType);


### PR DESCRIPTION
When running on tvOS 10.x it crashes on a full dump when it hits NSLeafProxy in Foundation:

./classdump-dyld -o tvOSH2 -c -D

   Now dumping /System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64...

2017-03-22 10:29:41.156 classdump-dyld[22900:558139] classdump-dyld : Current Image /usr/lib/libSystem.B.dylib
....
[truncated for brevity]
....
 72% [====================================              ]  450/624 <NSDocInfo>
2017-03-22 10:29:56.295 classdump-dyld[22900:558139] classdump-dyld : Processing Class NSDocumentSerializer
2017-03-22 10:29:56.303 classdump-dyld[22900:558139] classdump-dyld : Processing Class NSDirInfoSerializer
2017-03-22 10:29:56.341 classdump-dyld[22900:558139] classdump-dyld : Processing Class NSDirInfoDeserializer
2017-03-22 10:29:56.349 classdump-dyld[22900:558139] classdump-dyld : Processing Class NSLeafProxy
2017-03-22 10:29:56.350 classdump-dyld[22900:558139] *** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSSingleObjectArrayI objectAtIndex:]: index 1 beyond bounds [0 .. 0]'
*** First throw call stack:
(0x1961e251c 0x1957d455c 0x1961d3784 0x1000e87b4 0x1000ebec4 0x1000ef574 0x195c59674)
Abort trap: 6

I traced the error to this section of ParsingFunctions, there may be a more proper fix to this, but this at least prevents the crash from happening and allows it to run through the full cache dump successfully.